### PR TITLE
in GraphQLScalarTypeConfig parseValue and parseLiteral fields are optional

### DIFF
--- a/graphql.d.ts
+++ b/graphql.d.ts
@@ -657,8 +657,8 @@ interface GraphQLScalarTypeConfig {
     name: string;
     description?: string;
     serialize: (value: any) => any;
-    parseValue: (value: any) => any;
-    parseLiteral: (valueAST: Value) => any;
+    parseValue?: (value: any) => any;
+    parseLiteral?: (valueAST: Value) => any;
 }
 
 export class GraphQLObjectType {


### PR DESCRIPTION
see http://graphql.org/docs/api-reference-type-system/#graphqlscalartype
