### PR TITLE
Fix execute function signature

### DIFF
--- a/graphql.d.ts
+++ b/graphql.d.ts
@@ -63,6 +63,7 @@ function execute(
     schema: GraphQLSchema,
     documentAST: Document,
     rootValue?: any,
+    contextValue?: any,
     variableValues?: {[key: string]: any},
     operationName?: string
 ): Promise<ExecutionResult>;


### PR DESCRIPTION
This was updated in graphql 0.5.0 to include context argument
