### PR TITLE
Add definition of specifiedRules for validation

### DIFF
--- a/graphql.d.ts
+++ b/graphql.d.ts
@@ -88,6 +88,8 @@ function validate(
     rules?: Array<any>
 ): Array<GraphQLError>;
 
+export var specifiedRules: Array<any>;
+
 // jsutils/*.js
 
 function find<T>(list: Array<T>, predicate: (item: T) => boolean): T;


### PR DESCRIPTION
Technically this should be `Array<ValidationRule>` where `ValidationRule` is `Function(context: ValidationContext)` for the `ValidationContext` here: https://github.com/graphql/graphql-js/blob/master/src/validation/validate.js#L92, but I'm not sure how to write that. Maybe someone more versed with TypeScript can give it a try. For the time being `Array<any>` will at least make `specifiedRules` importable.
