### PR TITLE
Update graphql.d.ts

### DIFF
--- a/graphql.d.ts
+++ b/graphql.d.ts
@@ -988,8 +988,8 @@ declare module 'graphql' {
     getFieldDef(): GraphQLFieldDefinition;
     getDirective(): GraphQLDirective;
     getArgument(): GraphQLArgument;
-    enter(node: Node);
-    leave(node: Node);
+    enter(node: Node): void;
+    leave(node: Node): void;
     }
 
     function getFieldDef(


### PR DESCRIPTION
Fixing

```
ERROR in [default] /node_modules/graphql-typings/graphql.d.ts:990:4 
'enter', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in [default] /node_modules/graphql-typings/graphql.d.ts:991:4 
'leave', which lacks return-type annotation, implicitly has an 'any' return type.
```

when strict-compiling.
